### PR TITLE
_LOGGER object cannot be called so use `info` method instead to log i…

### DIFF
--- a/SOURCES/etc/xapi.d/plugins/zfs.py
+++ b/SOURCES/etc/xapi.d/plugins/zfs.py
@@ -17,8 +17,8 @@ from xcpngutils import configure_logging, run_command, error_wrapped
 def list_zfs_pools(session, args):
     try:
         command = ['zfs', 'get', '-H', 'all']
+        _LOGGER.info('executing command {}...'.format(command))
         result = run_command(command)
-        _LOGGER(command)
         lines = result['stdout'].splitlines()
         res = {}
 


### PR DESCRIPTION
…n ZFS plugin

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>