### PR TITLE
Handle when there's no RAID on the host

### DIFF
--- a/SOURCES/etc/xapi.d/plugins/raid.py
+++ b/SOURCES/etc/xapi.d/plugins/raid.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import json
+import subprocess
 import sys
 
 import XenAPIPlugin
@@ -18,7 +19,11 @@ _LOGGER = configure_logging('raid')
 def check_raid_pool(session, args):
     device = '/dev/md127'
     with OperationLocker():
-        result = run_command(['mdadm', '--detail', device])
+        try:
+            result = run_command(['mdadm', '--detail', device])
+        except subprocess.CalledProcessError:
+            # No RAID
+            return json.dumps({})
 
         lines = [line.strip() for line in result['stdout'].splitlines()]
         lines = [line for line in lines if len(line) > 0]


### PR DESCRIPTION
- Display `{}` if no raid `/dev/md127` was found.

Fixes: https://github.com/xcp-ng/xcp-ng-xapi-plugins/issues/27

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>