### PR TITLE
Fix issue in integration about smartctl and return error code 4

### DIFF
--- a/SOURCES/etc/xapi.d/plugins/smartctl.py
+++ b/SOURCES/etc/xapi.d/plugins/smartctl.py
@@ -24,7 +24,7 @@ def get_information(session, args):
     with OperationLocker():
         disks = _list_disks()
         for disk in disks:
-            cmd = run_command(["smartctl", "-j", "-a", disk])
+            cmd = run_command(["smartctl", "-j", "-a", disk], check=False)
             results[disk] = json.loads(cmd['stdout'])
         return json.dumps(results)
 


### PR DESCRIPTION
Some device doesn't support SMART capability and getting information from such device returns an error code 4. As it happens in CI we remove the check of the return code.