### PR TITLE
Add 2crsi-sensors plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,16 @@ xe host-call-plugin host-uuid=<uuid>  plugin=smartctl.py fn=health
 
 ## IPMI-sensors parser
 A xapi plugin to get information about the host via the BMC
+### `get_info`:
 ```
 xe host-call-plugin host-uuid=<uuid>  plugin=2crsi-sensors.py fn="get_info"
 [{"Name": "Outlet_Temp", "Event": "'OK'", "Units": "C", "Reading": "32.00", "Type": "Temperature"}, {"Name": "CPU0_Temp", "Event": "'OK'", "Units": "C", "Reading": "63.00", "Type": "Temperature"}, {"Name": "CPU1_Temp", "Event": "'OK'", "Units": "C", "Reading": "59.00", "Type": "Temperature"}, {"Name": "CPU0_DIMM_T", "Event": "'OK'", "Units": "C", "Reading": "38.00", "Type": "Temperature"}, {"Name": "CPU1_DIMM_T", "Event": "'OK'", "Units": "C", "Reading": "37.00", "Type": "Temperature"}, {"Name": "PSU_Inlet_Temp", "Event": "'OK'", "Units": "C", "Reading": "36.00", "Type": "Temperature"}, {"Name": "CPU0_VR_Temp", "Event": "'OK'", "Units": "C", "Reading": "43.00", "Type": "Temperature"}, {"Name": "CPU1_VR_Temp", "Event": "'OK'", "Units": "C", "Reading": "43.00", "Type": "Temperature"}, {"Name": "OCP_NIC_Temp", "Event": "'OK'", "Units": "C", "Reading": "60.00", "Type": "Temperature"} [...] }
+```
+
+### `get_ip`:
+```
+xe host-call-plugin host-uuid=<uuid>  plugin=2crsi-sensors.py fn="get_ip"
+10.10.1.191
 ```
 
 ## Netdata

--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ xe host-call-plugin host-uuid=<uuid>  plugin=smartctl.py fn=health
 {"/dev/sdf": "PASSED", "/dev/sdg": "PASSED", "/dev/sdd": "PASSED", "/dev/sde": "PASSED", "/dev/sdb": "PASSED", "/dev/sdc": "PASSED", "/dev/sda": "PASSED"}
 ```
 
+## IPMI-sensors parser
+A xapi plugin to get information about the host via the BMC
+```
+xe host-call-plugin host-uuid=<uuid>  plugin=2crsi-sensors.py fn="get_info"
+[{"Name": "Outlet_Temp", "Event": "'OK'", "Units": "C", "Reading": "32.00", "Type": "Temperature"}, {"Name": "CPU0_Temp", "Event": "'OK'", "Units": "C", "Reading": "63.00", "Type": "Temperature"}, {"Name": "CPU1_Temp", "Event": "'OK'", "Units": "C", "Reading": "59.00", "Type": "Temperature"}, {"Name": "CPU0_DIMM_T", "Event": "'OK'", "Units": "C", "Reading": "38.00", "Type": "Temperature"}, {"Name": "CPU1_DIMM_T", "Event": "'OK'", "Units": "C", "Reading": "37.00", "Type": "Temperature"}, {"Name": "PSU_Inlet_Temp", "Event": "'OK'", "Units": "C", "Reading": "36.00", "Type": "Temperature"}, {"Name": "CPU0_VR_Temp", "Event": "'OK'", "Units": "C", "Reading": "43.00", "Type": "Temperature"}, {"Name": "CPU1_VR_Temp", "Event": "'OK'", "Units": "C", "Reading": "43.00", "Type": "Temperature"}, {"Name": "OCP_NIC_Temp", "Event": "'OK'", "Units": "C", "Reading": "60.00", "Type": "Temperature"} [...] }
+```
+
 ## Netdata
 
 A xapi plugin to install and get api keys of netdata on the host.

--- a/SOURCES/etc/xapi.d/plugins/2crsi-sensors.py
+++ b/SOURCES/etc/xapi.d/plugins/2crsi-sensors.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import json
+import sys
+import XenAPIPlugin
+import re
+import subprocess
+
+sys.path.append('.')
+from xcpngutils import configure_logging, run_command, error_wrapped
+from xcpngutils.operationlocker import OperationLocker
+
+@error_wrapped
+def get_data(session, args):
+    data = subprocess.check_output(["ipmi-sensors", "-Q", "--ignore-not-available-sensors", "--ignore-unrecognized-events"])
+    data = str(data)
+    data = re.sub(r'\\n\d+', '\n', data)
+    data = data.replace('\\n', '\n')
+    # Split the data into lines
+    lines = data.splitlines()
+    
+    # Remove the header line
+    headers = lines[0].split('|')
+    lines = lines[1:]
+
+    # Strip whitespace from headers and create a list of header names
+    headers = [header.strip() for header in headers]
+
+    # Parse the remaining lines into a list of dictionaries
+    result = []
+    for line in lines[1:]:
+        columns = [col.strip() for col in line.split('|')]
+        if len(columns) == len(headers):
+            entry = {headers[i]: columns[i] for i in range(len(headers))}
+            # Remove the "ID" field from each entry
+            entry.pop("ID", None)
+            result.append(entry)
+
+    return json.dumps(result)
+
+_LOGGER = configure_logging('2crsi-sensors')
+if __name__ == "__main__":
+    XenAPIPlugin.dispatch({
+        'get_info': get_data
+    })

--- a/SOURCES/etc/xapi.d/plugins/2crsi-sensors.py
+++ b/SOURCES/etc/xapi.d/plugins/2crsi-sensors.py
@@ -39,8 +39,17 @@ def get_data(session, args):
 
     return json.dumps(result)
 
+def get_ip(session,args):
+    IP = subprocess.check_output(["ipmitool lan print | grep 'IP Address  '"], shell=True)
+    IP = str(IP)
+    IP = IP.replace(" ", "")
+    result =  re.findall(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", IP)
+    return result[0]
+
+
 _LOGGER = configure_logging('2crsi-sensors')
 if __name__ == "__main__":
     XenAPIPlugin.dispatch({
-        'get_info': get_data
+        'get_info': get_data,
+        'get_ip': get_ip
     })


### PR DESCRIPTION
This plugin allows XCP-ng to:
- Fetch data from the BMC and parse it into a JSON format
- Retrieve the IPMI's IP address

Thanks to this plugin, Xen Orchestra can display the BMC's sensors info and the IP address if a 2CRSi Mona server is detected
![image](https://github.com/user-attachments/assets/eda6ede4-8b94-4928-9975-655ca8b19466)

The plugin require the package `freeipmi` and `ipmitool`.
Tests requires a Mona server, if you need to test changes, contact me!